### PR TITLE
Refactor server constructors to take `ConfigHandle`

### DIFF
--- a/crates/chimney-cli/src/cli.rs
+++ b/crates/chimney-cli/src/cli.rs
@@ -128,7 +128,7 @@ impl Cli {
             .map_err(CliError::Filesystem)?;
 
         // Use new_with_tls to enable automatic TLS support
-        let server = Server::new_with_tls(Arc::new(fs), Arc::new(config))
+        let server = Server::new_with_tls(Arc::new(fs), config.into())
             .await
             .map_err(|e| CliError::Generic(format!("Failed to create server: {e}")))?;
 

--- a/crates/chimney-core/src/config/types/config.rs
+++ b/crates/chimney-core/src/config/types/config.rs
@@ -43,6 +43,13 @@ impl ConfigHandle {
     }
 }
 
+impl From<Config> for ConfigHandle {
+    fn from(val: Config) -> Self {
+        let (sender, receiver) = tokio::sync::watch::channel(Arc::new(val));
+        ConfigHandle::new(sender, receiver)
+    }
+}
+
 /// Represents the host detection options
 /// This is used to determine how the target host i.e. domain or IP address is detected from the
 /// request headers

--- a/crates/chimney-core/tests/server.rs
+++ b/crates/chimney-core/tests/server.rs
@@ -54,8 +54,7 @@ fn mock_config() -> Config {
 
 fn mock_server(config: Config) -> Server {
     let fs = Arc::new(filesystem::mock::MockFilesystem);
-    let config = Arc::new(config);
-    Server::new(fs, config)
+    Server::new(fs, config.into())
 }
 
 #[tokio::test]


### PR DESCRIPTION
`ConfigHandle` is way better to take than `Config` itself since the
former can be updated live while still keeping all of that in the
chimney core itself.
