### PR TITLE
Add library and CLI functionality to manually request certificates

### DIFF
--- a/crates/chimney-cli/src/cli.rs
+++ b/crates/chimney-cli/src/cli.rs
@@ -497,8 +497,8 @@ impl Cli {
             .map_err(|e| CliError::Generic(format!("Certificate request failed: {e}")))?;
 
         println!("\nCertificate issued successfully!");
-        println!("  Certificate: {}", result.cert_path.display());
-        println!("  Private key: {}", result.key_path.display());
+        println!("  Certificate: {}", result.certificate.cert.display());
+        println!("  Private key: {}", result.certificate.key.display());
         println!("\nDomains: {:?}", result.domains);
 
         if staging {

--- a/crates/chimney-cli/src/cli.rs
+++ b/crates/chimney-cli/src/cli.rs
@@ -497,8 +497,8 @@ impl Cli {
             .map_err(|e| CliError::Generic(format!("Certificate request failed: {e}")))?;
 
         println!("\nCertificate issued successfully!");
-        println!("  Certificate: {}", result.certificate.cert.display());
-        println!("  Private key: {}", result.certificate.key.display());
+        println!("  Certificate: {}", result.certificate.cert);
+        println!("  Private key: {}", result.certificate.key);
         println!("\nDomains: {:?}", result.domains);
 
         if staging {

--- a/crates/chimney-core/src/config/types/certificate.rs
+++ b/crates/chimney-core/src/config/types/certificate.rs
@@ -1,0 +1,109 @@
+use std::path::{Path, PathBuf};
+
+/// Represents a TLS certificate with its associated key and optional CA bundle.
+///
+/// This struct is used to configure manual TLS certificates for sites.
+///
+/// # Example
+/// ```
+/// use chimney::config::Certificate;
+///
+/// // Basic certificate with cert and key
+/// let cert = Certificate::new("./certs/cert.pem", "./certs/key.pem");
+///
+/// // Certificate with CA bundle
+/// let cert_with_ca = Certificate::new("./certs/cert.pem", "./certs/key.pem")
+///     .with_ca("./certs/ca.pem");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Certificate {
+    /// Path to the certificate PEM file
+    pub cert: String,
+    /// Path to the private key PEM file
+    pub key: String,
+    /// Path to the CA bundle PEM file (optional)
+    pub ca: Option<String>,
+}
+
+impl Certificate {
+    /// Creates a new certificate with the given cert and key paths.
+    pub fn new(cert: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            cert: cert.into(),
+            key: key.into(),
+            ca: None,
+        }
+    }
+
+    /// Adds a CA bundle path to the certificate.
+    pub fn with_ca(mut self, ca: impl Into<String>) -> Self {
+        self.ca = Some(ca.into());
+        self
+    }
+
+    /// Returns the certificate path as a `Path`.
+    pub fn cert_path(&self) -> &Path {
+        Path::new(&self.cert)
+    }
+
+    /// Returns the key path as a `Path`.
+    pub fn key_path(&self) -> &Path {
+        Path::new(&self.key)
+    }
+
+    /// Returns the CA path as an `Option<&Path>`.
+    pub fn ca_path(&self) -> Option<&Path> {
+        self.ca.as_ref().map(|s| Path::new(s.as_str()))
+    }
+}
+
+/// A certificate with `PathBuf` paths, typically used for results from certificate operations.
+///
+/// This is similar to `Certificate` but uses owned `PathBuf` instead of `String`,
+/// making it more suitable for representing file system paths in results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CertificatePaths {
+    /// Path to the certificate PEM file
+    pub cert: PathBuf,
+    /// Path to the private key PEM file
+    pub key: PathBuf,
+    /// Path to the CA bundle PEM file (optional)
+    pub ca: Option<PathBuf>,
+}
+
+impl CertificatePaths {
+    /// Creates a new certificate paths struct.
+    pub fn new(cert: impl Into<PathBuf>, key: impl Into<PathBuf>) -> Self {
+        Self {
+            cert: cert.into(),
+            key: key.into(),
+            ca: None,
+        }
+    }
+
+    /// Adds a CA bundle path.
+    pub fn with_ca(mut self, ca: impl Into<PathBuf>) -> Self {
+        self.ca = Some(ca.into());
+        self
+    }
+}
+
+impl From<Certificate> for CertificatePaths {
+    fn from(cert: Certificate) -> Self {
+        Self {
+            cert: PathBuf::from(cert.cert),
+            key: PathBuf::from(cert.key),
+            ca: cert.ca.map(PathBuf::from),
+        }
+    }
+}
+
+impl From<CertificatePaths> for Certificate {
+    fn from(paths: CertificatePaths) -> Self {
+        Self {
+            cert: paths.cert.to_string_lossy().into_owned(),
+            key: paths.key.to_string_lossy().into_owned(),
+            ca: paths.ca.map(|p| p.to_string_lossy().into_owned()),
+        }
+    }
+}

--- a/crates/chimney-core/src/config/types/mod.rs
+++ b/crates/chimney-core/src/config/types/mod.rs
@@ -1,8 +1,10 @@
+mod certificate;
 mod config;
 mod domain;
 mod log;
 mod site;
 
+pub use certificate::*;
 pub use config::*;
 pub use domain::*;
 pub use log::*;

--- a/crates/chimney-core/src/config/types/site.rs
+++ b/crates/chimney-core/src/config/types/site.rs
@@ -729,10 +729,7 @@ impl SiteBuilder {
         S: Into<String>,
     {
         for domain in domains {
-            let domain = domain.into();
-            if !self.domain_names.contains(&domain) {
-                self.domain_names.push(domain);
-            }
+            self = self.domain(domain);
         }
         self
     }

--- a/crates/chimney-core/src/config/types/site.rs
+++ b/crates/chimney-core/src/config/types/site.rs
@@ -334,6 +334,94 @@ impl Site {
         }
         self.response_headers.remove(header);
     }
+
+    /// Installs a TLS certificate for this site.
+    ///
+    /// This updates the site's `https_config` to use the specified certificate
+    /// and key files. The certificate will be used when the server starts or
+    /// when the configuration is reloaded.
+    ///
+    /// # Arguments
+    /// * `cert_path` - Path to the certificate PEM file
+    /// * `key_path` - Path to the private key PEM file
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let mut site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .build();
+    ///
+    /// site.install_certificate("./certs/cert.pem", "./certs/key.pem");
+    ///
+    /// assert!(site.https_config.is_some());
+    /// ```
+    pub fn install_certificate(
+        &mut self,
+        cert_path: impl Into<String>,
+        key_path: impl Into<String>,
+    ) {
+        let cert = cert_path.into();
+        let key = key_path.into();
+        debug!(
+            "Installing certificate for site '{}': cert={}, key={}",
+            self.name, cert, key
+        );
+        self.https_config = Some(Https {
+            auto_redirect: true,
+            cert_file: Some(cert),
+            key_file: Some(key),
+            ca_file: None,
+        });
+    }
+
+    /// Installs a TLS certificate with a CA bundle for this site.
+    ///
+    /// Similar to `install_certificate`, but also includes a CA bundle file
+    /// for certificate chain verification.
+    ///
+    /// # Arguments
+    /// * `cert_path` - Path to the certificate PEM file
+    /// * `key_path` - Path to the private key PEM file
+    /// * `ca_path` - Path to the CA bundle PEM file
+    pub fn install_certificate_with_ca(
+        &mut self,
+        cert_path: impl Into<String>,
+        key_path: impl Into<String>,
+        ca_path: impl Into<String>,
+    ) {
+        let cert = cert_path.into();
+        let key = key_path.into();
+        let ca = ca_path.into();
+        debug!(
+            "Installing certificate with CA for site '{}': cert={}, key={}, ca={}",
+            self.name, cert, key, ca
+        );
+        self.https_config = Some(Https {
+            auto_redirect: true,
+            cert_file: Some(cert),
+            key_file: Some(key),
+            ca_file: Some(ca),
+        });
+    }
+
+    /// Removes the TLS certificate configuration from this site.
+    ///
+    /// After calling this, the site will use ACME for automatic certificate
+    /// issuance (if global HTTPS is enabled).
+    pub fn uninstall_certificate(&mut self) {
+        debug!("Removing certificate configuration for site '{}'", self.name);
+        self.https_config = None;
+    }
+
+    /// Returns true if this site has a manually configured certificate.
+    pub fn has_installed_certificate(&self) -> bool {
+        self.https_config
+            .as_ref()
+            .map(|https| https.is_manual())
+            .unwrap_or(false)
+    }
 }
 
 impl Site {
@@ -556,5 +644,333 @@ impl Sites {
 
         debug!("Rebuilt index for site: {}", site.name);
         Ok(())
+    }
+}
+
+/// A builder for constructing `Site` configurations with a fluent API.
+///
+/// # Example
+///
+/// ```
+/// use chimney::config::SiteBuilder;
+///
+/// let site = SiteBuilder::new("my-site")
+///     .domain("example.com")
+///     .domain("www.example.com")
+///     .root("./public")
+///     .fallback_file("index.html")
+///     .response_header("X-Frame-Options", "DENY")
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct SiteBuilder {
+    name: String,
+    root: String,
+    domain_names: Vec<String>,
+    fallback_file: Option<String>,
+    default_index_file: Option<String>,
+    https_config: Option<Https>,
+    response_headers: HashMap<String, String>,
+    redirects: HashMap<String, RedirectRule>,
+    rewrites: HashMap<String, RewriteRule>,
+}
+
+impl SiteBuilder {
+    /// Creates a new `SiteBuilder` with the given site name.
+    ///
+    /// The name is required and cannot be changed after creation.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            root: Site::default_root_directory(),
+            domain_names: Vec::new(),
+            fallback_file: None,
+            default_index_file: None,
+            https_config: None,
+            response_headers: HashMap::new(),
+            redirects: HashMap::new(),
+            rewrites: HashMap::new(),
+        }
+    }
+
+    /// Adds a domain name to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .domain("www.example.com")
+    ///     .build();
+    /// ```
+    pub fn domain(mut self, domain: impl Into<String>) -> Self {
+        let domain = domain.into();
+        if !self.domain_names.contains(&domain) {
+            self.domain_names.push(domain);
+        }
+        self
+    }
+
+    /// Adds multiple domain names to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domains(["example.com", "www.example.com"])
+    ///     .build();
+    /// ```
+    pub fn domains<I, S>(mut self, domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for domain in domains {
+            let domain = domain.into();
+            if !self.domain_names.contains(&domain) {
+                self.domain_names.push(domain);
+            }
+        }
+        self
+    }
+
+    /// Sets the root directory for the site.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .root("./public")
+    ///     .build();
+    /// ```
+    pub fn root(mut self, root: impl Into<String>) -> Self {
+        self.root = root.into();
+        self
+    }
+
+    /// Sets the fallback file for the site (useful for SPAs).
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .fallback_file("index.html")
+    ///     .build();
+    /// ```
+    pub fn fallback_file(mut self, file: impl Into<String>) -> Self {
+        self.fallback_file = Some(file.into());
+        self
+    }
+
+    /// Sets the default index file for directory requests.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .default_index_file("index.htm")
+    ///     .build();
+    /// ```
+    pub fn default_index_file(mut self, file: impl Into<String>) -> Self {
+        self.default_index_file = Some(file.into());
+        self
+    }
+
+    /// Sets the HTTPS configuration for the site.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::{SiteBuilder, Https};
+    ///
+    /// let https = Https {
+    ///     auto_redirect: true,
+    ///     cert_file: Some("cert.pem".to_string()),
+    ///     key_file: Some("key.pem".to_string()),
+    ///     ca_file: None,
+    /// };
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .https(https)
+    ///     .build();
+    /// ```
+    pub fn https(mut self, config: Https) -> Self {
+        self.https_config = Some(config);
+        self
+    }
+
+    /// Sets manual TLS certificate paths for the site.
+    ///
+    /// This is a convenience method that creates an `Https` config with manual certificates.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .manual_cert("./certs/cert.pem", "./certs/key.pem")
+    ///     .build();
+    /// ```
+    pub fn manual_cert(
+        mut self,
+        cert_file: impl Into<String>,
+        key_file: impl Into<String>,
+    ) -> Self {
+        self.https_config = Some(Https {
+            auto_redirect: true,
+            cert_file: Some(cert_file.into()),
+            key_file: Some(key_file.into()),
+            ca_file: None,
+        });
+        self
+    }
+
+    /// Adds a response header to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .response_header("X-Frame-Options", "DENY")
+    ///     .response_header("X-Content-Type-Options", "nosniff")
+    ///     .build();
+    /// ```
+    pub fn response_header(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.response_headers.insert(name.into(), value.into());
+        self
+    }
+
+    /// Adds multiple response headers to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .response_headers([
+    ///         ("X-Frame-Options", "DENY"),
+    ///         ("X-Content-Type-Options", "nosniff"),
+    ///     ])
+    ///     .build();
+    /// ```
+    pub fn response_headers<I, K, V>(mut self, headers: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        for (name, value) in headers {
+            self.response_headers.insert(name.into(), value.into());
+        }
+        self
+    }
+
+    /// Adds a simple redirect rule to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .redirect("/old-path", "/new-path")
+    ///     .build();
+    /// ```
+    pub fn redirect(mut self, from: impl Into<String>, to: impl Into<String>) -> Self {
+        self.redirects
+            .insert(from.into(), RedirectRule::Target(to.into()));
+        self
+    }
+
+    /// Adds a redirect rule with full configuration to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::{SiteBuilder, RedirectRule};
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .redirect_rule("/old", RedirectRule::new("/new".to_string(), true, false))
+    ///     .build();
+    /// ```
+    pub fn redirect_rule(mut self, from: impl Into<String>, rule: RedirectRule) -> Self {
+        self.redirects.insert(from.into(), rule);
+        self
+    }
+
+    /// Adds a rewrite rule to the site.
+    ///
+    /// This method is chainable and can be called multiple times.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .rewrite("/api/*", "/backend/api/$1")
+    ///     .build();
+    /// ```
+    pub fn rewrite(mut self, from: impl Into<String>, to: impl Into<String>) -> Self {
+        self.rewrites
+            .insert(from.into(), RewriteRule::Target(to.into()));
+        self
+    }
+
+    /// Builds the `Site` from the configured options.
+    ///
+    /// # Example
+    /// ```
+    /// use chimney::config::SiteBuilder;
+    ///
+    /// let site = SiteBuilder::new("my-site")
+    ///     .domain("example.com")
+    ///     .root("./public")
+    ///     .build();
+    ///
+    /// assert_eq!(site.name, "my-site");
+    /// assert_eq!(site.domain_names, vec!["example.com"]);
+    /// assert_eq!(site.root, "./public");
+    /// ```
+    pub fn build(self) -> Site {
+        Site {
+            name: self.name,
+            root: self.root,
+            domain_names: self.domain_names,
+            fallback_file: self.fallback_file,
+            default_index_file: self.default_index_file,
+            https_config: self.https_config,
+            response_headers: self.response_headers,
+            redirects: self.redirects,
+            rewrites: self.rewrites,
+        }
     }
 }

--- a/crates/chimney-core/src/config/types/site.rs
+++ b/crates/chimney-core/src/config/types/site.rs
@@ -353,21 +353,15 @@ impl Site {
     ///     .domain("example.com")
     ///     .build();
     ///
-    /// site.install_certificate("./certs/cert.pem", "./certs/key.pem");
+    /// site.add_certificate("./certs/cert.pem", "./certs/key.pem");
     ///
     /// assert!(site.https_config.is_some());
     /// ```
-    pub fn install_certificate(
-        &mut self,
-        cert_path: impl Into<String>,
-        key_path: impl Into<String>,
-    ) {
+    pub fn add_certificate(&mut self, cert_path: impl Into<String>, key_path: impl Into<String>) {
         let cert = cert_path.into();
         let key = key_path.into();
-        debug!(
-            "Installing certificate for site '{}': cert={}, key={}",
-            self.name, cert, key
-        );
+        debug!("Installing certificate for site '{}'", self.name);
+
         self.https_config = Some(Https {
             auto_redirect: true,
             cert_file: Some(cert),
@@ -378,14 +372,14 @@ impl Site {
 
     /// Installs a TLS certificate with a CA bundle for this site.
     ///
-    /// Similar to `install_certificate`, but also includes a CA bundle file
+    /// Similar to `add_certificate`, but also includes a CA bundle file
     /// for certificate chain verification.
     ///
     /// # Arguments
     /// * `cert_path` - Path to the certificate PEM file
     /// * `key_path` - Path to the private key PEM file
     /// * `ca_path` - Path to the CA bundle PEM file
-    pub fn install_certificate_with_ca(
+    pub fn add_certificate_with_ca(
         &mut self,
         cert_path: impl Into<String>,
         key_path: impl Into<String>,
@@ -410,13 +404,16 @@ impl Site {
     ///
     /// After calling this, the site will use ACME for automatic certificate
     /// issuance (if global HTTPS is enabled).
-    pub fn uninstall_certificate(&mut self) {
-        debug!("Removing certificate configuration for site '{}'", self.name);
+    pub fn remove_certificate(&mut self) {
+        debug!(
+            "Removing certificate configuration for site '{}'",
+            self.name
+        );
         self.https_config = None;
     }
 
     /// Returns true if this site has a manually configured certificate.
-    pub fn has_installed_certificate(&self) -> bool {
+    pub fn has_certificate(&self) -> bool {
         self.https_config
             .as_ref()
             .map(|https| https.is_manual())
@@ -852,11 +849,7 @@ impl SiteBuilder {
     ///     .response_header("X-Content-Type-Options", "nosniff")
     ///     .build();
     /// ```
-    pub fn response_header(
-        mut self,
-        name: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Self {
+    pub fn response_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.response_headers.insert(name.into(), value.into());
         self
     }

--- a/crates/chimney-core/src/config/types/site.rs
+++ b/crates/chimney-core/src/config/types/site.rs
@@ -353,11 +353,11 @@ impl Site {
     ///     .domain("example.com")
     ///     .build();
     ///
-    /// site.add_certificate("./certs/cert.pem", "./certs/key.pem");
+    /// site.set_certificate("./certs/cert.pem", "./certs/key.pem");
     ///
     /// assert!(site.https_config.is_some());
     /// ```
-    pub fn add_certificate(&mut self, cert_path: impl Into<String>, key_path: impl Into<String>) {
+    pub fn set_certificate(&mut self, cert_path: impl Into<String>, key_path: impl Into<String>) {
         let cert = cert_path.into();
         let key = key_path.into();
         debug!("Installing certificate for site '{}'", self.name);
@@ -372,14 +372,14 @@ impl Site {
 
     /// Installs a TLS certificate with a CA bundle for this site.
     ///
-    /// Similar to `add_certificate`, but also includes a CA bundle file
+    /// Similar to `set_certificate`, but also includes a CA bundle file
     /// for certificate chain verification.
     ///
     /// # Arguments
     /// * `cert_path` - Path to the certificate PEM file
     /// * `key_path` - Path to the private key PEM file
     /// * `ca_path` - Path to the CA bundle PEM file
-    pub fn add_certificate_with_ca(
+    pub fn set_certificate_with_ca(
         &mut self,
         cert_path: impl Into<String>,
         key_path: impl Into<String>,

--- a/crates/chimney-core/src/tls/cert_request.rs
+++ b/crates/chimney-core/src/tls/cert_request.rs
@@ -17,7 +17,7 @@ use tokio::net::TcpListener;
 use tokio_rustls_acme::caches::DirCache;
 use tokio_rustls_acme::AcmeConfig;
 
-use crate::config::CertificatePaths;
+use crate::config::Certificate;
 use crate::error::ServerError;
 
 /// Default Let's Encrypt production directory URL
@@ -67,8 +67,8 @@ impl Default for CertRequestOptions {
 pub struct CertRequestResult {
     /// Domain names the certificate was issued for
     pub domains: Vec<String>,
-    /// Paths to the certificate and key files
-    pub certificate: CertificatePaths,
+    /// Certificate with paths to cert and key files
+    pub certificate: Certificate,
 }
 
 /// Request a TLS certificate for the specified domains via ACME
@@ -277,7 +277,7 @@ pub async fn request_certificate(options: CertRequestOptions) -> Result<CertRequ
 
     Ok(CertRequestResult {
         domains: options.domains,
-        certificate: CertificatePaths::new(cert_path, key_path),
+        certificate: Certificate::from_paths(cert_path, key_path),
     })
 }
 

--- a/crates/chimney-core/src/tls/cert_request.rs
+++ b/crates/chimney-core/src/tls/cert_request.rs
@@ -17,6 +17,7 @@ use tokio::net::TcpListener;
 use tokio_rustls_acme::caches::DirCache;
 use tokio_rustls_acme::AcmeConfig;
 
+use crate::config::CertificatePaths;
 use crate::error::ServerError;
 
 /// Default Let's Encrypt production directory URL
@@ -66,10 +67,8 @@ impl Default for CertRequestOptions {
 pub struct CertRequestResult {
     /// Domain names the certificate was issued for
     pub domains: Vec<String>,
-    /// Path to the certificate file
-    pub cert_path: PathBuf,
-    /// Path to the private key file
-    pub key_path: PathBuf,
+    /// Paths to the certificate and key files
+    pub certificate: CertificatePaths,
 }
 
 /// Request a TLS certificate for the specified domains via ACME
@@ -98,7 +97,7 @@ pub struct CertRequestResult {
 ///     };
 ///
 ///     let result = request_certificate(options).await?;
-///     println!("Certificate saved to: {:?}", result.cert_path);
+///     println!("Certificate saved to: {:?}", result.certificate.cert);
 ///     Ok(())
 /// }
 /// ```
@@ -278,8 +277,7 @@ pub async fn request_certificate(options: CertRequestOptions) -> Result<CertRequ
 
     Ok(CertRequestResult {
         domains: options.domains,
-        cert_path,
-        key_path,
+        certificate: CertificatePaths::new(cert_path, key_path),
     })
 }
 

--- a/crates/chimney-core/src/tls/cert_request.rs
+++ b/crates/chimney-core/src/tls/cert_request.rs
@@ -1,0 +1,387 @@
+// Standalone certificate request functionality for manual ACME certificate issuance
+//
+// This module provides the ability to request TLS certificates programmatically
+// without running the full server. Useful for:
+// - Pre-provisioning certificates before server startup
+// - Requesting certificates for sites added dynamically
+// - CLI-based certificate management
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use log::{debug, error, info};
+use tokio::net::TcpListener;
+use tokio_rustls_acme::caches::DirCache;
+use tokio_rustls_acme::AcmeConfig;
+
+use crate::error::ServerError;
+
+/// Default Let's Encrypt production directory URL
+pub const LETS_ENCRYPT_PRODUCTION_URL: &str = "https://acme-v02.api.letsencrypt.org/directory";
+
+/// Let's Encrypt staging directory URL (for testing)
+pub const LETS_ENCRYPT_STAGING_URL: &str = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+/// Options for requesting a TLS certificate via ACME
+#[derive(Debug, Clone)]
+pub struct CertRequestOptions {
+    /// Domain names to request certificate for
+    pub domains: Vec<String>,
+    /// Email address for ACME account registration
+    pub email: String,
+    /// ACME directory URL (e.g., Let's Encrypt production or staging)
+    pub directory_url: String,
+    /// Directory to cache certificates
+    pub cache_dir: PathBuf,
+    /// Port to bind for ACME TLS-ALPN-01 challenge (default: 443)
+    pub challenge_port: u16,
+    /// Timeout for certificate issuance (default: 5 minutes)
+    pub timeout: Duration,
+    /// Host address to bind to (default: 0.0.0.0)
+    pub bind_host: IpAddr,
+}
+
+impl Default for CertRequestOptions {
+    fn default() -> Self {
+        Self {
+            domains: Vec::new(),
+            email: String::new(),
+            directory_url: LETS_ENCRYPT_PRODUCTION_URL.to_string(),
+            cache_dir: PathBuf::from(".chimney/certs"),
+            challenge_port: 443,
+            timeout: Duration::from_secs(300), // 5 minutes
+            bind_host: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        }
+    }
+}
+
+/// Result of a successful certificate request
+#[derive(Debug, Clone)]
+pub struct CertRequestResult {
+    /// Domain names the certificate was issued for
+    pub domains: Vec<String>,
+    /// Path to the certificate file
+    pub cert_path: PathBuf,
+    /// Path to the private key file
+    pub key_path: PathBuf,
+}
+
+/// Request a TLS certificate for the specified domains via ACME
+///
+/// This function will:
+/// 1. Bind to the specified port for ACME TLS-ALPN-01 validation
+/// 2. Request a certificate from the ACME server
+/// 3. Wait for the certificate to be issued (or timeout)
+/// 4. Return the paths to the saved certificate files
+///
+/// # Requirements
+/// - Port 443 (or specified `challenge_port`) must be available
+/// - The domains must resolve to this server's IP address
+/// - The ACME directory must be reachable
+///
+/// # Example
+/// ```ignore
+/// use chimney::tls::cert_request::{request_certificate, CertRequestOptions};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let options = CertRequestOptions {
+///         domains: vec!["example.com".to_string()],
+///         email: "admin@example.com".to_string(),
+///         ..Default::default()
+///     };
+///
+///     let result = request_certificate(options).await?;
+///     println!("Certificate saved to: {:?}", result.cert_path);
+///     Ok(())
+/// }
+/// ```
+pub async fn request_certificate(options: CertRequestOptions) -> Result<CertRequestResult, ServerError> {
+    // Validate options
+    if options.domains.is_empty() {
+        return Err(ServerError::TlsInitializationFailed(
+            "At least one domain is required".to_string(),
+        ));
+    }
+
+    if options.email.is_empty() {
+        return Err(ServerError::TlsInitializationFailed(
+            "ACME email is required".to_string(),
+        ));
+    }
+
+    // Create site name from first domain (sanitized for filesystem)
+    let site_name = options.domains[0]
+        .replace('.', "_")
+        .replace('*', "wildcard");
+
+    // Validate site name and create cache directory
+    let site_cache_dir = super::cache::create_cert_directory(&site_name, &options.cache_dir)?;
+
+    info!(
+        "Requesting certificate for domains: {:?}",
+        options.domains
+    );
+    info!("Using ACME directory: {}", options.directory_url);
+    info!("Certificates will be cached in: {}", site_cache_dir.display());
+
+    // Install default crypto provider if not already installed
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    // Create ACME configuration
+    // Note: DirCache::new takes ownership of the path
+    let acme_config = AcmeConfig::new(options.domains.clone())
+        .contact_push(format!("mailto:{}", options.email))
+        .directory(&options.directory_url)
+        .cache(DirCache::new(site_cache_dir.clone()));
+
+    // Create ACME state
+    let mut state = acme_config.state();
+    let acceptor = state.acceptor();
+
+    // Bind to challenge port
+    let addr = SocketAddr::new(options.bind_host, options.challenge_port);
+    let listener = TcpListener::bind(addr).await.map_err(|e| {
+        ServerError::TlsInitializationFailed(format!(
+            "Failed to bind to {} for ACME challenge: {}. \
+             Ensure the port is available and you have sufficient permissions (port 443 typically requires root/admin).",
+            addr, e
+        ))
+    })?;
+
+    info!("Listening on {} for ACME TLS-ALPN-01 challenge", addr);
+
+    // Track certificate issuance errors
+    let cert_error = Arc::new(std::sync::Mutex::new(None::<String>));
+    let cert_error_clone = cert_error.clone();
+    let domains_for_log = options.domains.clone();
+
+    // Spawn ACME event handler
+    let event_handle = tokio::spawn(async move {
+        loop {
+            match state.next().await {
+                Some(Ok(event)) => {
+                    info!("ACME event for {:?}: {:?}", domains_for_log, event);
+                    // The tokio-rustls-acme library fires events and writes certificates
+                    // to the DirCache automatically. We just log events here and
+                    // check for file existence in the main loop.
+                }
+                Some(Err(err)) => {
+                    error!("ACME error: {:?}", err);
+                    let mut error_guard = cert_error_clone.lock().unwrap();
+                    *error_guard = Some(format!("{:?}", err));
+                    break;
+                }
+                None => {
+                    debug!("ACME state stream ended");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Accept connections for ACME challenge
+    let acceptor_clone = acceptor.clone();
+    let accept_handle = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer_addr)) => {
+                    debug!("Accepted connection from {} for ACME challenge", peer_addr);
+
+                    let acceptor_inner = acceptor_clone.clone();
+                    tokio::spawn(async move {
+                        match acceptor_inner.accept(stream).await {
+                            Ok(None) => {
+                                info!("Handled ACME TLS-ALPN-01 challenge from {}", peer_addr);
+                            }
+                            Ok(Some(_tls_stream)) => {
+                                debug!("Regular TLS connection from {} (not an ACME challenge)", peer_addr);
+                            }
+                            Err(e) => {
+                                error!("TLS accept error from {}: {}", peer_addr, e);
+                            }
+                        }
+                    });
+                }
+                Err(e) => {
+                    error!("Failed to accept connection: {}", e);
+                }
+            }
+        }
+    });
+
+    // Wait for certificate with timeout
+    let start = std::time::Instant::now();
+    let cert_path = site_cache_dir.join("cert.pem");
+    let key_path = site_cache_dir.join("key.pem");
+
+    loop {
+        // Check if we've exceeded timeout
+        if start.elapsed() > options.timeout {
+            // Cleanup
+            accept_handle.abort();
+            event_handle.abort();
+
+            // Check if there was an error
+            let error_guard = cert_error.lock().unwrap();
+            if let Some(err) = error_guard.as_ref() {
+                return Err(ServerError::AcmeCertificateIssuanceFailed(err.clone()));
+            }
+
+            return Err(ServerError::AcmeCertificateIssuanceFailed(
+                "Timeout waiting for certificate issuance. Ensure domains resolve to this server.".to_string(),
+            ));
+        }
+
+        // Check if certificate files exist (DirCache writes them automatically)
+        if cert_path.exists() && key_path.exists() {
+            // Verify the files are non-empty
+            let cert_meta = std::fs::metadata(&cert_path).ok();
+            let key_meta = std::fs::metadata(&key_path).ok();
+
+            if let (Some(cert_m), Some(key_m)) = (cert_meta, key_meta) {
+                if cert_m.len() > 0 && key_m.len() > 0 {
+                    info!("Certificate files found and verified");
+                    break;
+                }
+            }
+        }
+
+        // Check for errors
+        {
+            let error_guard = cert_error.lock().unwrap();
+            if let Some(err) = error_guard.as_ref() {
+                accept_handle.abort();
+                event_handle.abort();
+                return Err(ServerError::AcmeCertificateIssuanceFailed(err.clone()));
+            }
+        }
+
+        // Wait a bit before checking again
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // Cleanup
+    accept_handle.abort();
+    event_handle.abort();
+
+    info!("Certificate issued successfully!");
+    info!("Certificate: {}", cert_path.display());
+    info!("Private key: {}", key_path.display());
+
+    Ok(CertRequestResult {
+        domains: options.domains,
+        cert_path,
+        key_path,
+    })
+}
+
+/// Options builder for certificate requests.
+///
+/// Provides a fluent API for constructing `CertRequestOptions`.
+///
+/// # Example
+/// ```
+/// use chimney::tls::CertRequestOptionsBuilder;
+///
+/// let options = CertRequestOptionsBuilder::new()
+///     .domain("example.com")
+///     .domain("www.example.com")
+///     .email("admin@example.com")
+///     .staging()  // Use Let's Encrypt staging for testing
+///     .build();
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct CertRequestOptionsBuilder {
+    options: CertRequestOptions,
+}
+
+impl CertRequestOptionsBuilder {
+    /// Create a new options builder with defaults.
+    pub fn new() -> Self {
+        Self {
+            options: CertRequestOptions::default(),
+        }
+    }
+
+    /// Add a domain to request the certificate for.
+    ///
+    /// This method is chainable and can be called multiple times.
+    pub fn domain(mut self, domain: impl Into<String>) -> Self {
+        self.options.domains.push(domain.into());
+        self
+    }
+
+    /// Add multiple domains to request the certificate for.
+    ///
+    /// This method is chainable and can be called multiple times.
+    pub fn domains<I, S>(mut self, domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for domain in domains {
+            self.options.domains.push(domain.into());
+        }
+        self
+    }
+
+    /// Set the email address for ACME account registration.
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.options.email = email.into();
+        self
+    }
+
+    /// Set the ACME directory URL.
+    pub fn directory_url(mut self, url: impl Into<String>) -> Self {
+        self.options.directory_url = url.into();
+        self
+    }
+
+    /// Use Let's Encrypt staging environment (for testing).
+    ///
+    /// Staging certificates are not trusted by browsers but allow unlimited
+    /// requests, making them ideal for testing.
+    pub fn staging(mut self) -> Self {
+        self.options.directory_url = LETS_ENCRYPT_STAGING_URL.to_string();
+        self
+    }
+
+    /// Use Let's Encrypt production environment (default).
+    pub fn production(mut self) -> Self {
+        self.options.directory_url = LETS_ENCRYPT_PRODUCTION_URL.to_string();
+        self
+    }
+
+    /// Set the certificate cache directory.
+    pub fn cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.options.cache_dir = dir.into();
+        self
+    }
+
+    /// Set the port to bind for ACME challenge.
+    pub fn challenge_port(mut self, port: u16) -> Self {
+        self.options.challenge_port = port;
+        self
+    }
+
+    /// Set the timeout for certificate issuance.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.options.timeout = timeout;
+        self
+    }
+
+    /// Set the host address to bind to.
+    pub fn bind_host(mut self, host: IpAddr) -> Self {
+        self.options.bind_host = host;
+        self
+    }
+
+    /// Build the `CertRequestOptions`.
+    pub fn build(self) -> CertRequestOptions {
+        self.options
+    }
+}

--- a/crates/chimney-core/src/tls/mod.rs
+++ b/crates/chimney-core/src/tls/mod.rs
@@ -45,8 +45,18 @@
 pub mod acceptor;
 pub mod acme;
 pub mod cache;
+pub mod cert_request;
 pub mod config;
 pub mod manual;
+
+// Re-export cert_request types for convenience
+pub use cert_request::{
+    request_certificate, CertRequestOptions, CertRequestOptionsBuilder, CertRequestResult,
+    LETS_ENCRYPT_PRODUCTION_URL, LETS_ENCRYPT_STAGING_URL,
+};
+
+// Re-export manual certificate loading for users who need it
+pub use manual::load_certified_key;
 
 use std::{path::Path, sync::Arc};
 

--- a/crates/chimney-core/tests/cert_request.rs
+++ b/crates/chimney-core/tests/cert_request.rs
@@ -1,0 +1,123 @@
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use chimney::error::ServerError;
+use chimney::tls::{
+    request_certificate, CertRequestOptions, CertRequestOptionsBuilder,
+    LETS_ENCRYPT_PRODUCTION_URL, LETS_ENCRYPT_STAGING_URL,
+};
+
+#[test]
+fn test_cert_request_options_default() {
+    let options = CertRequestOptions::default();
+    assert!(options.domains.is_empty());
+    assert!(options.email.is_empty());
+    assert_eq!(options.challenge_port, 443);
+    assert_eq!(options.directory_url, LETS_ENCRYPT_PRODUCTION_URL);
+    assert_eq!(options.timeout, Duration::from_secs(300));
+}
+
+#[tokio::test]
+async fn test_request_certificate_validates_empty_domains() {
+    let options = CertRequestOptions {
+        domains: vec![],
+        email: "test@example.com".to_string(),
+        ..Default::default()
+    };
+
+    let result = request_certificate(options).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, ServerError::TlsInitializationFailed(_)));
+}
+
+#[tokio::test]
+async fn test_request_certificate_validates_empty_email() {
+    let options = CertRequestOptions {
+        domains: vec!["example.com".to_string()],
+        email: String::new(),
+        ..Default::default()
+    };
+
+    let result = request_certificate(options).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, ServerError::TlsInitializationFailed(_)));
+}
+
+#[test]
+fn test_lets_encrypt_urls() {
+    assert!(LETS_ENCRYPT_PRODUCTION_URL.contains("acme-v02"));
+    assert!(LETS_ENCRYPT_STAGING_URL.contains("staging"));
+}
+
+#[test]
+fn test_cert_request_options_builder_basic() {
+    let options = CertRequestOptionsBuilder::new()
+        .domain("example.com")
+        .email("admin@example.com")
+        .build();
+
+    assert_eq!(options.domains, vec!["example.com"]);
+    assert_eq!(options.email, "admin@example.com");
+    assert_eq!(options.directory_url, LETS_ENCRYPT_PRODUCTION_URL);
+}
+
+#[test]
+fn test_cert_request_options_builder_multiple_domains() {
+    let options = CertRequestOptionsBuilder::new()
+        .domain("example.com")
+        .domain("www.example.com")
+        .domains(["api.example.com", "admin.example.com"])
+        .email("admin@example.com")
+        .build();
+
+    assert_eq!(options.domains.len(), 4);
+    assert!(options.domains.contains(&"example.com".to_string()));
+    assert!(options.domains.contains(&"www.example.com".to_string()));
+    assert!(options.domains.contains(&"api.example.com".to_string()));
+    assert!(options.domains.contains(&"admin.example.com".to_string()));
+}
+
+#[test]
+fn test_cert_request_options_builder_staging() {
+    let options = CertRequestOptionsBuilder::new()
+        .domain("example.com")
+        .email("admin@example.com")
+        .staging()
+        .build();
+
+    assert_eq!(options.directory_url, LETS_ENCRYPT_STAGING_URL);
+}
+
+#[test]
+fn test_cert_request_options_builder_production() {
+    let options = CertRequestOptionsBuilder::new()
+        .domain("example.com")
+        .email("admin@example.com")
+        .staging()
+        .production() // Override staging
+        .build();
+
+    assert_eq!(options.directory_url, LETS_ENCRYPT_PRODUCTION_URL);
+}
+
+#[test]
+fn test_cert_request_options_builder_all_options() {
+    use std::net::Ipv4Addr;
+
+    let options = CertRequestOptionsBuilder::new()
+        .domain("example.com")
+        .email("admin@example.com")
+        .cache_dir("/custom/certs")
+        .challenge_port(8443)
+        .timeout(Duration::from_secs(600))
+        .bind_host(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        .build();
+
+    assert_eq!(options.cache_dir, PathBuf::from("/custom/certs"));
+    assert_eq!(options.challenge_port, 8443);
+    assert_eq!(options.timeout, Duration::from_secs(600));
+    assert_eq!(options.bind_host, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+}

--- a/crates/chimney-core/tests/cert_request.rs
+++ b/crates/chimney-core/tests/cert_request.rs
@@ -11,6 +11,7 @@ use chimney::tls::{
 #[test]
 fn test_cert_request_options_default() {
     let options = CertRequestOptions::default();
+    assert!(options.site_name.is_empty());
     assert!(options.domains.is_empty());
     assert!(options.email.is_empty());
     assert_eq!(options.challenge_port, 443);
@@ -21,6 +22,7 @@ fn test_cert_request_options_default() {
 #[tokio::test]
 async fn test_request_certificate_validates_empty_domains() {
     let options = CertRequestOptions {
+        site_name: "test-site".to_string(),
         domains: vec![],
         email: "test@example.com".to_string(),
         ..Default::default()
@@ -35,8 +37,24 @@ async fn test_request_certificate_validates_empty_domains() {
 #[tokio::test]
 async fn test_request_certificate_validates_empty_email() {
     let options = CertRequestOptions {
+        site_name: "test-site".to_string(),
         domains: vec!["example.com".to_string()],
         email: String::new(),
+        ..Default::default()
+    };
+
+    let result = request_certificate(options).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, ServerError::TlsInitializationFailed(_)));
+}
+
+#[tokio::test]
+async fn test_request_certificate_validates_empty_site_name() {
+    let options = CertRequestOptions {
+        site_name: String::new(),
+        domains: vec!["example.com".to_string()],
+        email: "test@example.com".to_string(),
         ..Default::default()
     };
 

--- a/crates/chimney-core/tests/site_builder.rs
+++ b/crates/chimney-core/tests/site_builder.rs
@@ -197,7 +197,7 @@ fn test_site_builder_full_example() {
 }
 
 #[test]
-fn test_site_add_certificate() {
+fn test_site_set_certificate() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .build();
@@ -205,7 +205,7 @@ fn test_site_add_certificate() {
     assert!(!site.has_certificate());
     assert!(site.https_config.is_none());
 
-    site.add_certificate("./certs/cert.pem", "./certs/key.pem");
+    site.set_certificate("./certs/cert.pem", "./certs/key.pem");
 
     assert!(site.has_certificate());
     assert!(site.https_config.is_some());
@@ -218,12 +218,12 @@ fn test_site_add_certificate() {
 }
 
 #[test]
-fn test_site_add_certificate_with_ca() {
+fn test_site_set_certificate_with_ca() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .build();
 
-    site.add_certificate_with_ca(
+    site.set_certificate_with_ca(
         "./certs/cert.pem",
         "./certs/key.pem",
         "./certs/ca.pem",
@@ -263,13 +263,13 @@ fn test_site_has_certificate_with_acme() {
 }
 
 #[test]
-fn test_site_add_certificate_overwrites_existing() {
+fn test_site_set_certificate_overwrites_existing() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .manual_cert("./old/cert.pem", "./old/key.pem")
         .build();
 
-    site.add_certificate("./new/cert.pem", "./new/key.pem");
+    site.set_certificate("./new/cert.pem", "./new/key.pem");
 
     let https = site.https_config.as_ref().unwrap();
     assert_eq!(https.cert_file, Some("./new/cert.pem".to_string()));

--- a/crates/chimney-core/tests/site_builder.rs
+++ b/crates/chimney-core/tests/site_builder.rs
@@ -1,0 +1,277 @@
+use chimney::config::{Https, RedirectRule, SiteBuilder};
+
+#[test]
+fn test_site_builder_basic() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .build();
+
+    assert_eq!(site.name, "my-site");
+    assert_eq!(site.domain_names, vec!["example.com"]);
+    assert_eq!(site.root, ".");
+}
+
+#[test]
+fn test_site_builder_multiple_domains() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .domain("www.example.com")
+        .domain("api.example.com")
+        .build();
+
+    assert_eq!(site.domain_names.len(), 3);
+    assert!(site.domain_names.contains(&"example.com".to_string()));
+    assert!(site.domain_names.contains(&"www.example.com".to_string()));
+    assert!(site.domain_names.contains(&"api.example.com".to_string()));
+}
+
+#[test]
+fn test_site_builder_domains_batch() {
+    let site = SiteBuilder::new("my-site")
+        .domains(["example.com", "www.example.com"])
+        .build();
+
+    assert_eq!(site.domain_names.len(), 2);
+}
+
+#[test]
+fn test_site_builder_no_duplicate_domains() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .domain("example.com")
+        .domains(["example.com", "other.com"])
+        .build();
+
+    assert_eq!(site.domain_names.len(), 2);
+    assert!(site.domain_names.contains(&"example.com".to_string()));
+    assert!(site.domain_names.contains(&"other.com".to_string()));
+}
+
+#[test]
+fn test_site_builder_root() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .root("./public")
+        .build();
+
+    assert_eq!(site.root, "./public");
+}
+
+#[test]
+fn test_site_builder_fallback_file() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .fallback_file("index.html")
+        .build();
+
+    assert_eq!(site.fallback_file, Some("index.html".to_string()));
+}
+
+#[test]
+fn test_site_builder_default_index_file() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .default_index_file("index.htm")
+        .build();
+
+    assert_eq!(site.default_index_file, Some("index.htm".to_string()));
+}
+
+#[test]
+fn test_site_builder_response_headers() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .response_header("X-Frame-Options", "DENY")
+        .response_header("X-Content-Type-Options", "nosniff")
+        .build();
+
+    assert_eq!(site.response_headers.len(), 2);
+    assert_eq!(site.response_headers.get("X-Frame-Options"), Some(&"DENY".to_string()));
+    assert_eq!(site.response_headers.get("X-Content-Type-Options"), Some(&"nosniff".to_string()));
+}
+
+#[test]
+fn test_site_builder_response_headers_batch() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .response_headers([
+            ("X-Frame-Options", "DENY"),
+            ("X-Content-Type-Options", "nosniff"),
+        ])
+        .build();
+
+    assert_eq!(site.response_headers.len(), 2);
+}
+
+#[test]
+fn test_site_builder_redirect() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .redirect("/old", "/new")
+        .build();
+
+    assert_eq!(site.redirects.len(), 1);
+    let rule = site.redirects.get("/old").unwrap();
+    assert_eq!(rule.target(), "/new");
+}
+
+#[test]
+fn test_site_builder_redirect_rule() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .redirect_rule("/old", RedirectRule::new("/new".to_string(), true, false))
+        .build();
+
+    assert_eq!(site.redirects.len(), 1);
+    let rule = site.redirects.get("/old").unwrap();
+    assert_eq!(rule.target(), "/new");
+    assert!(rule.is_temporary());
+}
+
+#[test]
+fn test_site_builder_rewrite() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .rewrite("/api/*", "/backend/api/$1")
+        .build();
+
+    assert_eq!(site.rewrites.len(), 1);
+    let rule = site.rewrites.get("/api/*").unwrap();
+    assert_eq!(rule.target(), "/backend/api/$1");
+}
+
+#[test]
+fn test_site_builder_manual_cert() {
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .manual_cert("./certs/cert.pem", "./certs/key.pem")
+        .build();
+
+    assert!(site.https_config.is_some());
+    let https = site.https_config.unwrap();
+    assert_eq!(https.cert_file, Some("./certs/cert.pem".to_string()));
+    assert_eq!(https.key_file, Some("./certs/key.pem".to_string()));
+    assert!(https.auto_redirect);
+}
+
+#[test]
+fn test_site_builder_https_config() {
+    let https = Https {
+        auto_redirect: false,
+        cert_file: Some("cert.pem".to_string()),
+        key_file: Some("key.pem".to_string()),
+        ca_file: Some("ca.pem".to_string()),
+    };
+
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .https(https)
+        .build();
+
+    assert!(site.https_config.is_some());
+    let config = site.https_config.unwrap();
+    assert!(!config.auto_redirect);
+    assert_eq!(config.ca_file, Some("ca.pem".to_string()));
+}
+
+#[test]
+fn test_site_builder_full_example() {
+    let site = SiteBuilder::new("my-app")
+        .domain("example.com")
+        .domain("www.example.com")
+        .root("./dist")
+        .fallback_file("index.html")
+        .default_index_file("index.html")
+        .response_header("X-Frame-Options", "DENY")
+        .redirect("/blog", "https://blog.example.com")
+        .rewrite("/api/*", "/backend/$1")
+        .build();
+
+    assert_eq!(site.name, "my-app");
+    assert_eq!(site.domain_names.len(), 2);
+    assert_eq!(site.root, "./dist");
+    assert_eq!(site.fallback_file, Some("index.html".to_string()));
+    assert_eq!(site.response_headers.len(), 1);
+    assert_eq!(site.redirects.len(), 1);
+    assert_eq!(site.rewrites.len(), 1);
+}
+
+#[test]
+fn test_site_install_certificate() {
+    let mut site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .build();
+
+    assert!(!site.has_installed_certificate());
+    assert!(site.https_config.is_none());
+
+    site.install_certificate("./certs/cert.pem", "./certs/key.pem");
+
+    assert!(site.has_installed_certificate());
+    assert!(site.https_config.is_some());
+
+    let https = site.https_config.as_ref().unwrap();
+    assert_eq!(https.cert_file, Some("./certs/cert.pem".to_string()));
+    assert_eq!(https.key_file, Some("./certs/key.pem".to_string()));
+    assert!(https.auto_redirect);
+    assert!(https.ca_file.is_none());
+}
+
+#[test]
+fn test_site_install_certificate_with_ca() {
+    let mut site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .build();
+
+    site.install_certificate_with_ca(
+        "./certs/cert.pem",
+        "./certs/key.pem",
+        "./certs/ca.pem",
+    );
+
+    assert!(site.has_installed_certificate());
+
+    let https = site.https_config.as_ref().unwrap();
+    assert_eq!(https.cert_file, Some("./certs/cert.pem".to_string()));
+    assert_eq!(https.key_file, Some("./certs/key.pem".to_string()));
+    assert_eq!(https.ca_file, Some("./certs/ca.pem".to_string()));
+}
+
+#[test]
+fn test_site_uninstall_certificate() {
+    let mut site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .manual_cert("./certs/cert.pem", "./certs/key.pem")
+        .build();
+
+    assert!(site.has_installed_certificate());
+
+    site.uninstall_certificate();
+
+    assert!(!site.has_installed_certificate());
+    assert!(site.https_config.is_none());
+}
+
+#[test]
+fn test_site_has_installed_certificate_with_acme() {
+    // Site with no https_config uses ACME (not manual cert)
+    let site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .build();
+
+    assert!(!site.has_installed_certificate());
+}
+
+#[test]
+fn test_site_install_certificate_overwrites_existing() {
+    let mut site = SiteBuilder::new("my-site")
+        .domain("example.com")
+        .manual_cert("./old/cert.pem", "./old/key.pem")
+        .build();
+
+    site.install_certificate("./new/cert.pem", "./new/key.pem");
+
+    let https = site.https_config.as_ref().unwrap();
+    assert_eq!(https.cert_file, Some("./new/cert.pem".to_string()));
+    assert_eq!(https.key_file, Some("./new/key.pem".to_string()));
+}

--- a/crates/chimney-core/tests/site_builder.rs
+++ b/crates/chimney-core/tests/site_builder.rs
@@ -197,17 +197,17 @@ fn test_site_builder_full_example() {
 }
 
 #[test]
-fn test_site_install_certificate() {
+fn test_site_add_certificate() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .build();
 
-    assert!(!site.has_installed_certificate());
+    assert!(!site.has_certificate());
     assert!(site.https_config.is_none());
 
-    site.install_certificate("./certs/cert.pem", "./certs/key.pem");
+    site.add_certificate("./certs/cert.pem", "./certs/key.pem");
 
-    assert!(site.has_installed_certificate());
+    assert!(site.has_certificate());
     assert!(site.https_config.is_some());
 
     let https = site.https_config.as_ref().unwrap();
@@ -218,18 +218,18 @@ fn test_site_install_certificate() {
 }
 
 #[test]
-fn test_site_install_certificate_with_ca() {
+fn test_site_add_certificate_with_ca() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .build();
 
-    site.install_certificate_with_ca(
+    site.add_certificate_with_ca(
         "./certs/cert.pem",
         "./certs/key.pem",
         "./certs/ca.pem",
     );
 
-    assert!(site.has_installed_certificate());
+    assert!(site.has_certificate());
 
     let https = site.https_config.as_ref().unwrap();
     assert_eq!(https.cert_file, Some("./certs/cert.pem".to_string()));
@@ -238,38 +238,38 @@ fn test_site_install_certificate_with_ca() {
 }
 
 #[test]
-fn test_site_uninstall_certificate() {
+fn test_site_remove_certificate() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .manual_cert("./certs/cert.pem", "./certs/key.pem")
         .build();
 
-    assert!(site.has_installed_certificate());
+    assert!(site.has_certificate());
 
-    site.uninstall_certificate();
+    site.remove_certificate();
 
-    assert!(!site.has_installed_certificate());
+    assert!(!site.has_certificate());
     assert!(site.https_config.is_none());
 }
 
 #[test]
-fn test_site_has_installed_certificate_with_acme() {
+fn test_site_has_certificate_with_acme() {
     // Site with no https_config uses ACME (not manual cert)
     let site = SiteBuilder::new("my-site")
         .domain("example.com")
         .build();
 
-    assert!(!site.has_installed_certificate());
+    assert!(!site.has_certificate());
 }
 
 #[test]
-fn test_site_install_certificate_overwrites_existing() {
+fn test_site_add_certificate_overwrites_existing() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
         .manual_cert("./old/cert.pem", "./old/key.pem")
         .build();
 
-    site.install_certificate("./new/cert.pem", "./new/key.pem");
+    site.add_certificate("./new/cert.pem", "./new/key.pem");
 
     let https = site.https_config.as_ref().unwrap();
     assert_eq!(https.cert_file, Some("./new/cert.pem".to_string()));

--- a/crates/chimney-core/tests/site_builder.rs
+++ b/crates/chimney-core/tests/site_builder.rs
@@ -1,4 +1,4 @@
-use chimney::config::{Https, RedirectRule, SiteBuilder};
+use chimney::config::{Certificate, Https, RedirectRule, SiteBuilder};
 
 #[test]
 fn test_site_builder_basic() {
@@ -141,10 +141,10 @@ fn test_site_builder_rewrite() {
 }
 
 #[test]
-fn test_site_builder_manual_cert() {
+fn test_site_builder_certificate() {
     let site = SiteBuilder::new("my-site")
         .domain("example.com")
-        .manual_cert("./certs/cert.pem", "./certs/key.pem")
+        .certificate(Certificate::new("./certs/cert.pem", "./certs/key.pem"))
         .build();
 
     assert!(site.https_config.is_some());
@@ -205,7 +205,7 @@ fn test_site_set_certificate() {
     assert!(!site.has_certificate());
     assert!(site.https_config.is_none());
 
-    site.set_certificate("./certs/cert.pem", "./certs/key.pem");
+    site.set_certificate(Certificate::new("./certs/cert.pem", "./certs/key.pem"));
 
     assert!(site.has_certificate());
     assert!(site.https_config.is_some());
@@ -223,10 +223,9 @@ fn test_site_set_certificate_with_ca() {
         .domain("example.com")
         .build();
 
-    site.set_certificate_with_ca(
-        "./certs/cert.pem",
-        "./certs/key.pem",
-        "./certs/ca.pem",
+    site.set_certificate(
+        Certificate::new("./certs/cert.pem", "./certs/key.pem")
+            .with_ca("./certs/ca.pem"),
     );
 
     assert!(site.has_certificate());
@@ -241,7 +240,7 @@ fn test_site_set_certificate_with_ca() {
 fn test_site_remove_certificate() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
-        .manual_cert("./certs/cert.pem", "./certs/key.pem")
+        .certificate(Certificate::new("./certs/cert.pem", "./certs/key.pem"))
         .build();
 
     assert!(site.has_certificate());
@@ -266,10 +265,10 @@ fn test_site_has_certificate_with_acme() {
 fn test_site_set_certificate_overwrites_existing() {
     let mut site = SiteBuilder::new("my-site")
         .domain("example.com")
-        .manual_cert("./old/cert.pem", "./old/key.pem")
+        .certificate(Certificate::new("./old/cert.pem", "./old/key.pem"))
         .build();
 
-    site.set_certificate("./new/cert.pem", "./new/key.pem");
+    site.set_certificate(Certificate::new("./new/cert.pem", "./new/key.pem"));
 
     let https = site.https_config.as_ref().unwrap();
     assert_eq!(https.cert_file, Some("./new/cert.pem".to_string()));


### PR DESCRIPTION
## Summary

Implements #60 - adds the ability to programmatically request TLS certificates for sites via ACME.

- Add `SiteBuilder` for fluent site construction with chainable methods
- Add `Site::install_certificate()` and related methods for certificate management
- Add `request_certificate()` library function for ACME certificate requests
- Add `request_and_install_certificate()` combined function
- Add `CertRequestOptionsBuilder` for fluent options construction
- Add `request-cert` CLI command for requesting certificates

## Library Usage

```rust
use chimney::config::SiteBuilder;
use chimney::tls::{request_and_install_certificate, CertRequestOptionsBuilder};

// Create a site with the builder
let mut site = SiteBuilder::new("my-site")
    .domain("example.com")
    .domain("www.example.com")
    .root("./public")
    .build();

// Request and install certificate
let options = CertRequestOptionsBuilder::new()
    .domains(site.domain_names.clone())
    .email("admin@example.com")
    .staging()
    .build();

let result = request_and_install_certificate(&mut site, options).await?;
```

## CLI Usage

```bash
# Basic usage
chimney request-cert -d example.com -e admin@example.com

# Multiple domains
chimney request-cert -d example.com -d www.example.com -e admin@example.com

# Staging (for testing)
chimney request-cert -d example.com -e admin@example.com --staging
```

## Test plan

- [x] All 117 existing tests pass
- [x] New unit tests for `SiteBuilder` (15 tests)
- [x] New unit tests for `CertRequestOptionsBuilder` (5 tests)
- [x] New unit tests for `Site::install_certificate` methods (5 tests)
- [x] CLI help displays correctly for new command
- [ ] Manual test with real domain (requires DNS + port 443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)